### PR TITLE
Updated polyphase filter

### DIFF
--- a/misc/filter/coefficients_generate.py
+++ b/misc/filter/coefficients_generate.py
@@ -1,0 +1,24 @@
+import numpy as np
+from gnuradio import filter
+
+samp_rate=10e6
+rolloff=0.2
+taps=100
+
+coeffs_floating = filter.firdes.root_raised_cosine(1.0, samp_rate, samp_rate/2, rolloff, taps) 
+
+output_width = 16
+
+factor = 0.5
+
+coeffs_fixed_twos = []
+for coeff in coeffs_floating:
+
+    if coeff < 0:
+        coeffs_fixed_twos.append( 0xFFFF & int(np.floor(((factor*coeff) + 2**output_width) * 2**(output_width-1))) )
+    else:
+        coeffs_fixed_twos.append( 0xFFFF & int(np.floor((factor*coeff) * 2**(output_width-1))) )
+
+    print("x%04X" % coeffs_fixed_twos[-1])
+
+

--- a/rtl/dvbs2_tx.vhd
+++ b/rtl/dvbs2_tx.vhd
@@ -61,6 +61,8 @@ entity dvbs2_tx is
     bit_mapper_ram_wdata    : in  std_logic_vector(DATA_WIDTH - 1 downto 0);
     bit_mapper_ram_rdata    : out std_logic_vector(DATA_WIDTH - 1 downto 0);
     -- Polyphase filter coefficients interface
+    coeffs_axi_aclk         : in  std_logic;
+    coeffs_axi_aresetn      : in  std_logic;
     coeffs_axi_awvalid      : in  std_logic;
     coeffs_axi_awready      : out std_logic;
     coeffs_axi_awaddr       : in  std_logic_vector(C_AXI_ADDR_WIDTH-1 downto 0);
@@ -497,8 +499,8 @@ begin
       data_out_tlast          => m_tlast_i,
       data_out_tvalid         => m_tvalid_i,
       -- coefficients input interface
-      coeffs_axi_aclk         => clk,
-      coeffs_axi_aresetn      => rst_n,
+      coeffs_axi_aclk         => coeffs_axi_aclk,
+      coeffs_axi_aresetn      => coeffs_axi_aresetn,
       coeffs_axi_awvalid      => coeffs_axi_awvalid,
       coeffs_axi_awready      => coeffs_axi_awready,
       coeffs_axi_awaddr       => coeffs_axi_awaddr,
@@ -543,8 +545,8 @@ begin
       data_out_tlast          => open,
       data_out_tvalid         => open,
       -- coefficients input interface
-      coeffs_axi_aclk         => clk,
-      coeffs_axi_aresetn      => rst_n,
+      coeffs_axi_aclk         => coeffs_axi_aclk,
+      coeffs_axi_aresetn      => coeffs_axi_aresetn,
       coeffs_axi_awvalid      => coeffs_axi_awvalid,
       coeffs_axi_awready      => open,
       coeffs_axi_awaddr       => coeffs_axi_awaddr,

--- a/testbench/dvbs2_tx_tb.vhd
+++ b/testbench/dvbs2_tx_tb.vhd
@@ -257,6 +257,8 @@ begin
       bit_mapper_ram_wdata    => bit_mapper_ram_wdata,
       bit_mapper_ram_rdata    => bit_mapper_ram_rdata,
       -- Polyphase filter coefficients interface
+      coeffs_axi_aclk         => clk,
+      coeffs_axi_aresetn      => not rst,
       coeffs_axi_awvalid      => '0',
       coeffs_axi_awready      => open,
       coeffs_axi_awaddr       => (others => '0'),

--- a/third_party/polyphase_filter/fir_filter.v
+++ b/third_party/polyphase_filter/fir_filter.v
@@ -1,320 +1,351 @@
-`timescale 1 ns / 1 ps
+`timescale 1 ns / 1 ns
 
 module fir_filter #
 (
-	parameter integer NUMBER_TAPS 			= 16,
-	parameter integer DATA_IN_WIDTH 		= 16,
-	parameter integer COEFFICIENT_WIDTH 	= 16,
-	parameter integer DATA_OUT_WIDTH 		= 16,
-	parameter integer FIR_OFFSET 			= -2,
-	parameter integer EMPTY_ON_TLAST		= 1
+    parameter integer NUMBER_TAPS 			= 16,
+    parameter integer DATA_IN_WIDTH 		= 16,
+    parameter integer COEFFICIENT_WIDTH 	= 16,
+    parameter integer DATA_OUT_WIDTH 		= 16,
+    parameter integer FIR_OFFSET 			= -2,
+    parameter integer EMPTY_ON_TLAST		= 1,
+    parameter	C_AXI_ADDR_WIDTH            = 4,
+    parameter	C_AXI_DATA_WIDTH            = 32,
+    parameter [0:0]	OPT_SKIDBUFFER          = 1'b0,
+    parameter [0:0]	OPT_LOWPOWER            = 0,
+    parameter	ADDRLSB                     = $clog2(C_AXI_DATA_WIDTH)-3
 )
 (
-	// input data interface
-	input wire  							data_in_aclk,
-	input wire  							data_in_aresetn,
-	output wire								data_in_tready,
-	input wire 	[DATA_IN_WIDTH-1:0] 		data_in_tdata,
-	input wire  							data_in_tlast,
-	input wire  							data_in_tvalid,
+    // input data interface
+    input  wire  							data_in_aclk,
+    input  wire  							data_in_aresetn,
+    output wire								data_in_tready,
+    input  wire [DATA_IN_WIDTH-1:0] 		data_in_tdata,
+    input  wire  							data_in_tlast,
+    input  wire  							data_in_tvalid,
 
-	// output data interface
-	input wire  							data_out_aclk,
-	input wire  							data_out_aresetn,
-	input wire 								data_out_tready,
-	output wire [DATA_OUT_WIDTH-1:0] 		data_out_tdata,
-	output wire 							data_out_tlast,
-	output wire 							data_out_tvalid,
+    // output data interface
+    input  wire  							data_out_aclk,
+    input  wire  							data_out_aresetn,
+    input  wire 							data_out_tready,
+    output wire [DATA_OUT_WIDTH-1:0] 		data_out_tdata,
+    output wire 							data_out_tlast,
+    output wire 							data_out_tvalid,
 
-	// coefficients input interface
-	input wire  							coefficients_in_aclk,
-	input wire  							coefficients_in_aresetn,
-	output wire 							coefficients_in_tready,
-	input wire 	[COEFFICIENT_WIDTH-1 : 0]	coefficients_in_tdata,
-	input wire  							coefficients_in_tlast,
-	input wire  							coefficients_in_tvalid,
+    // coeffs input interface
+    input  wire								coeffs_axi_aclk,
+    input  wire								coeffs_axi_aresetn,
+    input  wire								coeffs_axi_awvalid,
+    output wire								coeffs_axi_awready,
+    input  wire [C_AXI_ADDR_WIDTH-1:0]		coeffs_axi_awaddr,
+    input  wire [2:0]						coeffs_axi_awprot,
+    input  wire								coeffs_axi_wvalid,
+    output wire								coeffs_axi_wready,
+    input  wire [C_AXI_DATA_WIDTH-1:0]		coeffs_axi_wdata,
+    input  wire [C_AXI_DATA_WIDTH/8-1:0]	coeffs_axi_wstrb,
+    // output reg								coeffs_axi_bvalid,
+    output wire 							coeffs_axi_bvalid,
+    input  wire								coeffs_axi_bready,
+    output wire [1:0]						coeffs_axi_bresp,
+    input  wire								coeffs_axi_arvalid,
+    output wire								coeffs_axi_arready,
+    input  wire [C_AXI_ADDR_WIDTH-1:0]		coeffs_axi_araddr,
+    input  wire [2:0]						coeffs_axi_arprot,
+    output wire								coeffs_axi_rvalid,
+    input  wire								coeffs_axi_rready,
+    output wire [C_AXI_DATA_WIDTH-1:0]		coeffs_axi_rdata,
+    output wire [1:0]						coeffs_axi_rresp,
 
-	// flags
-	output wire								samples_remaining
+    // flags
+    output  wire							samples_remaining
 );
-	// internal parameters
-	localparam INPUT_DELAY 	= 0;
-	localparam CARRY_LENGTH = INPUT_DELAY+NUMBER_TAPS;
-	localparam CARRY_WIDTH 	= 48;
-	localparam MAC_DELAY 	= 2;
-	localparam FILTER_DELAY	= NUMBER_TAPS+MAC_DELAY;
-	localparam TLAST_DELAY	= FILTER_DELAY+NUMBER_TAPS-1;
+    // internal parameters
+    localparam INPUT_DELAY 			= 0;
+    localparam CARRY_LENGTH 		= INPUT_DELAY+NUMBER_TAPS;
+    localparam CARRY_WIDTH 			= 48;
+    localparam MAC_DELAY 			= 2;
+    localparam FILTER_DELAY			= NUMBER_TAPS+MAC_DELAY;
+    localparam TLAST_DELAY			= FILTER_DELAY+NUMBER_TAPS-1;
 
-	// global signals
-	wire 							clock;
-	wire 							reset;
-	wire 							empty_remaining;
+    // global signals
+    wire 							clock;
+    wire 							reset;
+    wire 							empty_remaining;
 
-	wire [DATA_IN_WIDTH-1:0]		filter_data_in;
-	wire [DATA_OUT_WIDTH-1:0]		data_out;
+    wire [DATA_IN_WIDTH-1:0]		filter_data_in;
+    wire [DATA_OUT_WIDTH-1:0]		data_out;
 
-	// propagating signals
-	reg [CARRY_LENGTH-1:0] 			ce_carry;
-	reg [CARRY_LENGTH-1:0] 			tlast_carry;
-	wire [DATA_IN_WIDTH-1:0] 		data_carry [CARRY_LENGTH-1:0];
-	wire [CARRY_WIDTH-1:0] 			calc_carry [CARRY_LENGTH-1:0];
+    // propagating signals
+    reg [CARRY_LENGTH-1:0] 			ce_carry;
+    reg [CARRY_LENGTH-1:0] 			tlast_carry;
+    wire [DATA_IN_WIDTH-1:0] 		data_carry [CARRY_LENGTH-1:0];
+    wire [CARRY_WIDTH-1:0] 			calc_carry [CARRY_LENGTH-1:0];
 
-	// coeffient signals
-	wire 							coefficient_reset;
-	wire [COEFFICIENT_WIDTH-1:0]	coefficient_in;
-	reg [$clog2(NUMBER_TAPS)-1:0]	coefficient_index;
-	reg [NUMBER_TAPS-1:0] 			coefficient_load_en;
+    // coeffient signals
+    wire 							coefficient_reset;
+    wire [COEFFICIENT_WIDTH-1:0]	coefficient_in;
+    reg [$clog2(NUMBER_TAPS)-1:0]	coefficient_index;
+    reg [NUMBER_TAPS-1:0] 			coefficient_load_en;
 
-	// filter delay lines
-	reg [FILTER_DELAY-1:0]			tvalid_delay_line;
-	reg [TLAST_DELAY-1:0]			tlast_delay_line;
-
-
-	reg 							tlast_latch;
-	reg [$clog2(TLAST_DELAY)-1:0]	tlast_clear_count;
+    // filter delay lines
+    reg [FILTER_DELAY-1:0]			tvalid_delay_line;
+    reg [TLAST_DELAY-1:0]			tlast_delay_line;
 
 
-
-
-	// map the input data clock
-	assign clock = data_in_aclk;
-
-	// reset either from external assertion or output of frame complete
-	assign reset = !data_in_aresetn | (data_out_tlast & data_out_tvalid & data_out_tready);
-
-	// pass the output ready signal to the input
-	assign data_in_tready = data_out_tready;
-
-	// map the output
-	assign data_out_tdata = data_out;
-
-	// combine the enable signals
-	assign empty_remaining = |tlast_delay_line & data_out_tready;
-
-	// signal that there is still samples in the delay line
-	assign samples_remaining = |tvalid_delay_line;
-
-	// output is valid as long as the previous clock enable of the last
-	// DSP48E1 was high
-	assign data_out_tvalid = tvalid_delay_line[FILTER_DELAY-1];
-
-	// pass through the tlast signal
-	assign data_out_tlast = tlast_delay_line[TLAST_DELAY-1];
-
-	// create delay lines for the valid and last signals
-	//  TODO I'm not happy with this yet as it will not clear if the number of valid inputs is 
-	//       less than the delay line width.  Ideally this should be fixed
-	assign filter_data_in = tlast_latch ? 0 : data_in_tdata;
-
-
-	// latch the last signal once it's been read in
-	always @(posedge clock) begin
-		if (reset) begin
-			tlast_latch <= 0;
-		end
-		else begin
-			if (data_in_tvalid & data_in_tready) begin
-				tlast_latch <= tlast_latch | data_in_tlast;
-			end
-			else begin
-				tlast_latch <= tlast_latch;
-			end
-		end
-	end
-
-
-	// operate the delay line of the valid and last signals
-	always @(posedge clock) begin
-		if (reset) begin
-			tvalid_delay_line <= 0;
-			tlast_delay_line <= 0;
-			tlast_clear_count <= 0;
-		end
-		else begin
-
-			// we need to clear out remaining samples within the delay line			
-			if (tlast_latch & empty_remaining) begin
-				tlast_clear_count <= tlast_clear_count + 1;
-				tvalid_delay_line <= {tvalid_delay_line[FILTER_DELAY-2:0], 1'b1};
-				tlast_delay_line <= {tlast_delay_line[TLAST_DELAY-2:0], data_in_tlast};
-			end
-
-			// a valid input sample has been provided or we're clearing the output
-			//  so increment the delay line
-			else if ((data_in_tready & data_in_tvalid) | empty_remaining) begin
-				tlast_clear_count <= tlast_clear_count;
-				tvalid_delay_line <= {tvalid_delay_line[FILTER_DELAY-2:0], data_in_tvalid};
-				tlast_delay_line <= {tlast_delay_line[TLAST_DELAY-2:0], data_in_tlast};
-			end
-
-			// register the signal
-			else begin
-				tlast_clear_count <= tlast_clear_count;
-				tvalid_delay_line <= tvalid_delay_line;
-				tlast_delay_line <= tlast_delay_line;
-			end
-		end
-	end
-
-
-
-	//// create the coefficient loading signals
-
-	// TODO: For now assume that coefficients AXI interface is clocked
-	// 		 at the same rate as the DSP48E1.  This will need to change
-	//		 for serial/parallel implementation where we will want to 
-	//		 clock the DSP48E1 at a much higher rate.  Need to figure out
-	//		 the best way to clock in at a lower rate possibly with the
-	//		 interaction between the coefficient bus clock and register A
-	//		 clock enable. 
-
-	// allow the AXI interface to reset the loaded coefficients
-	assign coefficient_reset = !coefficients_in_aresetn; 
-
-	// coefficients always ready - maybe not a good idea?
-	assign coefficients_in_tready = 1;
-
-	// map the input coefficients to the instance
-	assign coefficient_in = coefficients_in_tdata[COEFFICIENT_WIDTH-1:0];
-
-	// increment the coefficient index if a coefficient has been loaded
-	always @(posedge clock) begin
-		if (coefficient_reset) begin
-			coefficient_index <= 0;
-		end
-		else begin
-			if (coefficients_in_tvalid & coefficients_in_tready) begin
-				coefficient_index <= coefficient_index + 1;
-			end
-		end
-	end
-
-	// create coefficient load enable signals
-	integer i=0;
-	always @* begin
-		for (i=0; i < NUMBER_TAPS; i=i+1) begin
-			coefficient_load_en[i] <= (coefficient_index == i & coefficients_in_tvalid) ? 1: 0;
-		end
-	end
-
-	// shift the clock enable signal
-	always @(posedge clock) begin
-		if(reset) begin
-			ce_carry <= 0;
-			tlast_carry <= 0;
-		end
-		else begin
-			// only propagate if the output is ready to receive data
-			if(data_out_tready) begin
-
-				// shift the signals along
-				ce_carry <= {ce_carry[CARRY_LENGTH-2:0], data_in_tvalid};
-				tlast_carry <= {tlast_carry[CARRY_LENGTH-2:0], data_in_tlast};
-			end
-		end
-	end
+    reg 							tlast_latch;
+    reg [$clog2(TLAST_DELAY)-1:0]	tlast_clear_count;
 
 
 
 
-	// create the DSP chain
-	genvar index;
-	generate
-	for (index=0; index < NUMBER_TAPS; index=index+1)
-		begin : macs
+    // map the input data clock
+    assign clock = data_in_aclk;
 
-			if (index==0) begin
-				multiply_accumulate_behavioural #(
-					.DATA_WIDTH(DATA_IN_WIDTH),
-					.COEFFICIENT_WIDTH(COEFFICIENT_WIDTH),
-					.CARRY_WIDTH(CARRY_WIDTH),
-					.OUTPUT_OFFSET(FIR_OFFSET),
-					.DATA_IN_NUMBER_REGS(1),
-					.COEFFICIENTS_NUMBER_REGS(2),
-					.USE_SILICON_CARRY(1),
-					.FIRST_IN_CHAIN(1),
-					.LAST_IN_CHAIN(0)
-				) mac_inst (
-					.clock(clock),
-					.reset(reset),
-					.data_in(filter_data_in),
-					.coefficient_in(coefficient_in),
-					.carry_in({CARRY_WIDTH{1'b0}}),
-					.carry_out(calc_carry[index]),
-					.data_carry(data_carry[index]),
-					.data_out(),
-					.ce_calculate((data_in_tvalid & data_in_tready & data_in_tvalid) | empty_remaining),
-					.ce_coefficient(coefficient_load_en[index]),
-					.reset_coefficient(coefficient_reset),
-					.op_mode(7'b0000101),
-					.in_mode(5'b00001)
-				);
-			end
-			else if (index==NUMBER_TAPS-1) begin
-				multiply_accumulate_behavioural #(
-					.DATA_WIDTH(DATA_IN_WIDTH),
-					.COEFFICIENT_WIDTH(COEFFICIENT_WIDTH),
-					.CARRY_WIDTH(CARRY_WIDTH),
-					.OUTPUT_OFFSET(FIR_OFFSET),
-					.DATA_IN_NUMBER_REGS(2),
-					.COEFFICIENTS_NUMBER_REGS(2),
-					.USE_SILICON_CARRY(1),
-					.FIRST_IN_CHAIN(0),
-					.LAST_IN_CHAIN(1)
-				) mac_inst (
-					.clock(clock),
-					.reset(reset),
-					.data_in(data_carry[index-1]),
-					.coefficient_in(coefficient_in),
-					.carry_in(calc_carry[index-1]),
-					.carry_out(),
-					.data_carry(data_carry[index]),
-					.data_out(data_out),
-					.ce_calculate((tvalid_delay_line[index-1] & data_in_tready & data_in_tvalid) | empty_remaining),
-					.ce_coefficient(coefficient_load_en[index]),
-					.reset_coefficient(coefficient_reset),
-					.op_mode(7'b0010101),
-					.in_mode(5'b00001)
-				);
-			end
-			else begin
-				multiply_accumulate_behavioural #(
-					.DATA_WIDTH(DATA_IN_WIDTH),
-					.COEFFICIENT_WIDTH(COEFFICIENT_WIDTH),
-					.CARRY_WIDTH(CARRY_WIDTH),
-					.OUTPUT_OFFSET(FIR_OFFSET),
-					.DATA_IN_NUMBER_REGS(2),
-					.COEFFICIENTS_NUMBER_REGS(2),
-					.USE_SILICON_CARRY(1),
-					.FIRST_IN_CHAIN(0),
-					.LAST_IN_CHAIN(0)
-				) mac_inst (
-					.clock(clock),
-					.reset(reset),
-					.data_in(data_carry[index-1]),
-					.coefficient_in(coefficient_in),
-					.carry_in(calc_carry[index-1]),
-					.carry_out(calc_carry[index]),
-					.data_carry(data_carry[index]),
-					.data_out(),
-					.ce_calculate((tvalid_delay_line[index-1] & data_in_tready & data_in_tvalid) | empty_remaining),
-					.ce_coefficient(coefficient_load_en[index]),
-					.reset_coefficient(coefficient_reset),
-					.op_mode(7'b0010101),
-					.in_mode(5'b00001)
-				);
-			end
-		end
-	endgenerate
+    // reset either from external assertion or output of frame complete
+    assign reset = !data_in_aresetn | (data_out_tlast & data_out_tvalid & data_out_tready);
+
+    // pass the output ready signal to the input
+    assign data_in_tready = data_out_tready;
+
+    // map the output
+    assign data_out_tdata = data_out;
+
+    // combine the enable signals
+    assign empty_remaining = |tlast_delay_line & data_out_tready;
+
+    // signal that there is still samples in the delay line
+    assign samples_remaining = |tvalid_delay_line;
+
+    // output is valid as long as the previous clock enable of the last
+    // DSP48E1 was high
+    assign data_out_tvalid = tvalid_delay_line[FILTER_DELAY-1];
+
+    // pass through the tlast signal
+    assign data_out_tlast = tlast_delay_line[TLAST_DELAY-1];
+
+    // create delay lines for the valid and last signals
+    //  TODO I'm not happy with this yet as it will not clear if the number of valid inputs is 
+    //       less than the delay line width.  Ideally this should be fixed
+    assign filter_data_in = tlast_latch ? 0 : data_in_tdata;
 
 
-	// used to create the GTKwave dump file
-	`ifdef COCOTB_SIM
-			initial begin
-			$dumpfile ("waveform.vcd");
-			$dumpvars (0, fir_filter);
-			#1;
-		end
-	`endif
+    // latch the last signal once it's been read in
+    always @(posedge clock) begin
+        if (reset) begin
+            tlast_latch <= 0;
+        end
+        else begin
+            if (data_in_tvalid & data_in_tready) begin
+                tlast_latch <= tlast_latch | data_in_tlast;
+            end
+            else begin
+                tlast_latch <= tlast_latch;
+            end
+        end
+    end
+
+
+    // operate the delay line of the valid and last signals
+    always @(posedge clock) begin
+        if (reset) begin
+            tvalid_delay_line <= 0;
+            tlast_delay_line <= 0;
+            tlast_clear_count <= 0;
+        end
+        else begin
+
+            // we need to clear out remaining samples within the delay line			
+            if (tlast_latch & empty_remaining) begin
+                tlast_clear_count <= tlast_clear_count + 1;
+                tvalid_delay_line <= {tvalid_delay_line[FILTER_DELAY-2:0], 1'b1};
+                tlast_delay_line <= {tlast_delay_line[TLAST_DELAY-2:0], data_in_tlast};
+            end
+
+            // a valid input sample has been provided or we're clearing the output
+            //  so increment the delay line
+            else if ((data_in_tready & data_in_tvalid) | empty_remaining) begin
+                tlast_clear_count <= tlast_clear_count;
+                tvalid_delay_line <= {tvalid_delay_line[FILTER_DELAY-2:0], data_in_tvalid};
+                tlast_delay_line <= {tlast_delay_line[TLAST_DELAY-2:0], data_in_tlast};
+            end
+
+            // register the signal
+            else begin
+                tlast_clear_count <= tlast_clear_count;
+                tvalid_delay_line <= tvalid_delay_line;
+                tlast_delay_line <= tlast_delay_line;
+            end
+        end
+    end
+
+
+
+    //// create the coefficient loading signals
+
+    // TODO: For now assume that coeffs AXI interface is clocked
+    // 		 at the same rate as the DSP48E1.  This will need to change
+    //		 for serial/parallel implementation where we will want to 
+    //		 clock the DSP48E1 at a much higher rate.  Need to figure out
+    //		 the best way to clock in at a lower rate possibly with the
+    //		 interaction between the coefficient bus clock and register A
+    //		 clock enable. 
+
+    // allow the AXI interface to reset the loaded coeffs
+    assign coefficient_reset = !coeffs_axi_aresetn; 
+
+    // coeffs always ready - maybe not a good idea?
+    assign coeffs_axi_wready = 1;
+
+    // map the input coeffs to the instance
+    assign coefficient_in = coeffs_axi_wdata[COEFFICIENT_WIDTH-1:0];
+
+    // increment the coefficient index if a coefficient has been loaded
+    always @(posedge clock) begin
+        if (coefficient_reset) begin
+            coefficient_index <= 0;
+        end
+        else begin
+            if (coeffs_axi_wvalid & coeffs_axi_wready) begin
+                coefficient_index <= coefficient_index + 1;
+            end
+        end
+    end
+
+    // create coefficient load enable signals
+    integer i=0;
+    always @* begin
+        for (i=0; i < NUMBER_TAPS; i=i+1) begin
+            coefficient_load_en[i] = (coefficient_index == i & coeffs_axi_wvalid) ? 1: 0;
+        end
+    end
+
+    // shift the clock enable signal
+    always @(posedge clock) begin
+        if(reset) begin
+            ce_carry <= 0;
+            tlast_carry <= 0;
+        end
+        else begin
+            // only propagate if the output is ready to receive data
+            if(data_out_tready) begin
+
+                // shift the signals along
+                ce_carry <= {ce_carry[CARRY_LENGTH-2:0], data_in_tvalid};
+                tlast_carry <= {tlast_carry[CARRY_LENGTH-2:0], data_in_tlast};
+            end
+        end
+    end
+
+
+
+
+    // create the DSP chain
+    genvar index;
+    generate
+    for (index=0; index < NUMBER_TAPS; index=index+1)
+        begin : macs
+
+            if (index==0) begin
+                multiply_accumulate_behavioural #(
+                    .DATA_WIDTH(DATA_IN_WIDTH),
+                    .COEFFICIENT_WIDTH(COEFFICIENT_WIDTH),
+                    .CARRY_WIDTH(CARRY_WIDTH),
+                    .OUTPUT_OFFSET(FIR_OFFSET),
+                    .DATA_IN_NUMBER_REGS(1),
+                    .COEFFICIENTS_NUMBER_REGS(2),
+                    .USE_SILICON_CARRY(1),
+                    .FIRST_IN_CHAIN(1),
+                    .LAST_IN_CHAIN(0)
+                ) mac_inst (
+                    .clock(clock),
+                    .reset(reset),
+                    .data_in(filter_data_in),
+                    .coefficient_in(coefficient_in),
+                    .carry_in({CARRY_WIDTH{1'b0}}),
+                    .carry_out(calc_carry[index]),
+                    .data_carry(data_carry[index]),
+                    .data_out(),
+                    .ce_calculate((data_in_tvalid & data_in_tready & data_in_tvalid) | empty_remaining),
+                    .ce_coefficient(coefficient_load_en[index]),
+                    .reset_coefficient(coefficient_reset),
+                    .op_mode(7'b0000101),
+                    .in_mode(5'b00001)
+                );
+            end
+            else if (index==NUMBER_TAPS-1) begin
+                multiply_accumulate_behavioural #(
+                    .DATA_WIDTH(DATA_IN_WIDTH),
+                    .COEFFICIENT_WIDTH(COEFFICIENT_WIDTH),
+                    .CARRY_WIDTH(CARRY_WIDTH),
+                    .OUTPUT_OFFSET(FIR_OFFSET),
+                    .DATA_IN_NUMBER_REGS(2),
+                    .COEFFICIENTS_NUMBER_REGS(2),
+                    .USE_SILICON_CARRY(1),
+                    .FIRST_IN_CHAIN(0),
+                    .LAST_IN_CHAIN(1)
+                ) mac_inst (
+                    .clock(clock),
+                    .reset(reset),
+                    .data_in(data_carry[index-1]),
+                    .coefficient_in(coefficient_in),
+                    .carry_in(calc_carry[index-1]),
+                    .carry_out(),
+                    .data_carry(data_carry[index]),
+                    .data_out(data_out),
+                    .ce_calculate((tvalid_delay_line[index-1] & data_in_tready & data_in_tvalid) | empty_remaining),
+                    .ce_coefficient(coefficient_load_en[index]),
+                    .reset_coefficient(coefficient_reset),
+                    .op_mode(7'b0010101),
+                    .in_mode(5'b00001)
+                );
+            end
+            else begin
+                multiply_accumulate_behavioural #(
+                    .DATA_WIDTH(DATA_IN_WIDTH),
+                    .COEFFICIENT_WIDTH(COEFFICIENT_WIDTH),
+                    .CARRY_WIDTH(CARRY_WIDTH),
+                    .OUTPUT_OFFSET(FIR_OFFSET),
+                    .DATA_IN_NUMBER_REGS(2),
+                    .COEFFICIENTS_NUMBER_REGS(2),
+                    .USE_SILICON_CARRY(1),
+                    .FIRST_IN_CHAIN(0),
+                    .LAST_IN_CHAIN(0)
+                ) mac_inst (
+                    .clock(clock),
+                    .reset(reset),
+                    .data_in(data_carry[index-1]),
+                    .coefficient_in(coefficient_in),
+                    .carry_in(calc_carry[index-1]),
+                    .carry_out(calc_carry[index]),
+                    .data_carry(data_carry[index]),
+                    .data_out(),
+                    .ce_calculate((tvalid_delay_line[index-1] & data_in_tready & data_in_tvalid) | empty_remaining),
+                    .ce_coefficient(coefficient_load_en[index]),
+                    .reset_coefficient(coefficient_reset),
+                    .op_mode(7'b0010101),
+                    .in_mode(5'b00001)
+                );
+            end
+        end
+    endgenerate
+
+    // terminate AXI signals
+    assign coeffs_axi_bresp = 2'b00;
+    assign coeffs_axi_rresp = 2'b00;
+
+    assign coeffs_axi_bvalid    = 1'b1;
+    assign coeffs_axi_awready   = 1'b1;
+    assign coeffs_axi_rvalid    = 1'b0;
+    assign coeffs_axi_arready   = 1'b1;
+    assign coeffs_axi_rdata     = {C_AXI_DATA_WIDTH{1'b0}};
+
+
+    // used to create the GTKwave dump file
+    `ifdef COCOTB_SIM
+            initial begin
+            $dumpfile ("waveform.vcd");
+            $dumpvars (0, fir_filter);
+            #1;
+        end
+    `endif
 
 endmodule

--- a/third_party/polyphase_filter/multiply_accumulate_behavioural.v
+++ b/third_party/polyphase_filter/multiply_accumulate_behavioural.v
@@ -115,7 +115,7 @@ module multiply_accumulate_behavioural #
 
     // output the trimmed and full precision outputs
     assign carry_out = mac_value;
-    assign data_out = mac_value[2*DATA_WIDTH-2-1+:DATA_WIDTH];
+    assign data_out = mac_value[2*DATA_WIDTH-2-1:DATA_WIDTH-2];
 
 
     // used to create the GTKwave dump file

--- a/third_party/polyphase_filter/polyphase_filter.v
+++ b/third_party/polyphase_filter/polyphase_filter.v
@@ -1,273 +1,307 @@
 /*
-	Interpolating polyphase filter.
+    Interpolating polyphase filter.
 
-	Currently only supports interpolation.
+    Currently only supports interpolation.
 */
 
-`timescale 1 ns / 1 ps
+`timescale 1 ns / 1 ns
 
-module polyphase_filter #
-(
-	parameter integer NUMBER_TAPS 				= 32,
-	parameter integer DATA_IN_WIDTH 			= 16,
-	parameter integer DATA_OUT_WIDTH 			= 16,
-	parameter integer COEFFICIENT_WIDTH 		= 16,
-	parameter integer RATE_CHANGE 				= 8,
-	parameter integer DECIMATE_INTERPOLATE 		= 1 // 0 = decimate, 1 = interpolate
+module polyphase_filter #(
+    parameter integer NUMBER_TAPS               = 32,
+    parameter integer DATA_IN_WIDTH             = 16,
+    parameter integer DATA_OUT_WIDTH            = 16,
+    parameter integer COEFFICIENT_WIDTH         = 16,
+    parameter integer RATE_CHANGE               = 8,
+    parameter integer DECIMATE_INTERPOLATE      = 1, // 0 = decimate, 1 = interpolate
+    parameter integer C_AXI_ADDR_WIDTH          = 4,
+    parameter integer C_AXI_DATA_WIDTH          = 32,
+    parameter [0:0]   OPT_SKIDBUFFER            = 1'b0,
+    parameter [0:0]   OPT_LOWPOWER              = 0,
+    parameter integer ADDRLSB                   = $clog2(C_AXI_DATA_WIDTH)-3
 )
 (
-	// input data interface
-	input wire  						data_in_aclk,
-	input wire  						data_in_aresetn,
-	output wire							data_in_tready,
-	input wire 	[DATA_IN_WIDTH-1:0] 	data_in_tdata,
-	input wire  						data_in_tlast,
-	input wire  						data_in_tvalid,
+    // input data interface
+    input wire                              data_in_aclk,
+    input wire                              data_in_aresetn,
+    output wire                             data_in_tready,
+    input wire     [DATA_IN_WIDTH-1:0]      data_in_tdata,
+    input wire                              data_in_tlast,
+    input wire                              data_in_tvalid,
 
-	// output data interface
-	input wire  						data_out_aclk,
-	input wire  						data_out_aresetn,
-	input wire 							data_out_tready,
-	output wire [DATA_OUT_WIDTH-1:0] 	data_out_tdata,
-	output wire							data_out_tlast,
-	output wire							data_out_tvalid,
+    // output data interface
+    input wire                              data_out_aclk,
+    input wire                              data_out_aresetn,
+    input wire                              data_out_tready,
+    output wire [DATA_OUT_WIDTH-1:0]        data_out_tdata,
+    output wire                             data_out_tlast,
+    output wire                             data_out_tvalid,
 
-	// coefficients input interface
-	input wire  						coefficients_in_aclk,
-	input wire  						coefficients_in_aresetn,
-	output wire 						coefficients_in_tready,
-	input wire 	[COEFFICIENT_WIDTH-1:0]	coefficients_in_tdata,
-	input wire  						coefficients_in_tlast,
-	input wire  						coefficients_in_tvalid
+    // coeffs input interface
+    input  wire                             coeffs_axi_aclk,
+    input  wire                             coeffs_axi_aresetn,
+    input  wire                             coeffs_axi_awvalid,
+    output wire                             coeffs_axi_awready,
+    input  wire [C_AXI_ADDR_WIDTH-1:0]      coeffs_axi_awaddr,
+    input  wire [2:0]                       coeffs_axi_awprot,
+    input  wire                             coeffs_axi_wvalid,
+    output wire                             coeffs_axi_wready,
+    input  wire [C_AXI_DATA_WIDTH-1:0]      coeffs_axi_wdata,
+    input  wire [C_AXI_DATA_WIDTH/8-1:0]    coeffs_axi_wstrb,
+    output wire                             coeffs_axi_bvalid,
+    input  wire                             coeffs_axi_bready,
+    output wire [1:0]                       coeffs_axi_bresp,
+    input  wire                             coeffs_axi_arvalid,
+    output wire                             coeffs_axi_arready,
+    input  wire [C_AXI_ADDR_WIDTH-1:0]      coeffs_axi_araddr,
+    input  wire [2:0]                       coeffs_axi_arprot,
+    output wire                             coeffs_axi_rvalid,
+    input  wire                             coeffs_axi_rready,
+    output wire [C_AXI_DATA_WIDTH-1:0]      coeffs_axi_rdata,
+    output wire [1:0]                       coeffs_axi_rresp
 );
 
-	// internal parameters
-	localparam AXI_WIDTH 					= 32;
-	localparam INPUT_DELAY 					= 1;
-	localparam SUB_LENGTH 					= NUMBER_TAPS/RATE_CHANGE;
-	localparam CARRY_LENGTH 				= SUB_LENGTH + RATE_CHANGE + INPUT_DELAY;
-	localparam INTERP_WIDTH 				= $clog2(RATE_CHANGE);
-	localparam RATE_COUNT_WIDTH 			= $clog2(RATE_CHANGE);
-	localparam SUB_COUNT_WIDTH 				= $clog2(SUB_LENGTH);
-	localparam DATA_CARRY_LENGTH 			= RATE_CHANGE+2;
-	localparam DATA_REV_CARRY_LENGTH 		= RATE_CHANGE+2;
-	localparam CALC_CARRY_LENGTH 			= RATE_CHANGE;		// there's two delays lacking in the carry path in the DSP48 so need to add them here
-	localparam DATA_REV_DELAY_CARRY_LENGTH 	= RATE_CHANGE+2;
-	localparam OUTPUT_SHIFT					= $clog2(NUMBER_TAPS)*0;
+    // internal parameters
+    localparam AXI_WIDTH                    = 32;
+    localparam INPUT_DELAY                  = 1;
+    localparam SUB_LENGTH                   = NUMBER_TAPS/RATE_CHANGE;
+    localparam CARRY_LENGTH                 = SUB_LENGTH + RATE_CHANGE + INPUT_DELAY;
+    localparam INTERP_WIDTH                 = $clog2(RATE_CHANGE);
+    localparam RATE_COUNT_WIDTH             = $clog2(RATE_CHANGE);
+    localparam SUB_COUNT_WIDTH              = $clog2(SUB_LENGTH);
+    localparam DATA_CARRY_LENGTH            = RATE_CHANGE+2;
+    localparam DATA_REV_CARRY_LENGTH        = RATE_CHANGE+2;
+    localparam CALC_CARRY_LENGTH            = RATE_CHANGE;        // there's two delays lacking in the carry path in the DSP48 so need to add them here
+    localparam DATA_REV_DELAY_CARRY_LENGTH  = RATE_CHANGE+2;
+    localparam OUTPUT_SHIFT                 = $clog2(NUMBER_TAPS)*0;
 
-	// global signals
-	wire 							clock;
-	wire 							reset;
+    // global signals
+    wire                                clock;
+    wire                                reset;
 
-	// monitor the current phase in the upsampling/downsampling
-	reg [$clog2(RATE_CHANGE)-1:0]	phase_counter;
-
-
-	// FIR filter connection signals
-	reg [DATA_IN_WIDTH-1:0]			data_in_tdata_array [RATE_CHANGE-1:0];
-	wire [RATE_CHANGE-1:0]			data_in_tready_array;
-	reg [RATE_CHANGE-1:0]			data_in_tvalid_array;
-	reg [RATE_CHANGE-1:0]			data_in_tlast_array;
-	reg								data_in_tlast_latched;
-	wire [DATA_OUT_WIDTH-1:0]		data_out_tdata_array [RATE_CHANGE-1:0];
-	wire [RATE_CHANGE-1:0]			data_out_tready_array;
-	wire [RATE_CHANGE-1:0]			data_out_tvalid_array;
-	wire [RATE_CHANGE-1:0]			data_out_tlast_array;
-	wire [RATE_CHANGE-1:0]			coefficients_in_tready_array;
-	reg [RATE_CHANGE-1:0]			coefficients_in_tvalid_array;
-	wire [RATE_CHANGE-1:0]			coefficients_in_tlast_array;
-
-	wire [RATE_CHANGE-1:0]			samples_remaining_array;
+    // monitor the current phase in the upsampling/downsampling
+    reg [$clog2(RATE_CHANGE)-1:0]       phase_counter;
 
 
-	// select the highest frequency clock
-	assign clock = DECIMATE_INTERPOLATE ? data_out_aclk : data_in_aclk;
+    // FIR filter connection signals
+    reg [DATA_IN_WIDTH-1:0]             data_in_tdata_array [RATE_CHANGE-1:0];
+    wire [RATE_CHANGE-1:0]              data_in_tready_array;
+    reg [RATE_CHANGE-1:0]               data_in_tvalid_array;
+    reg [RATE_CHANGE-1:0]               data_in_tlast_array;
+    reg                                 data_in_tlast_latched;
+    wire [DATA_OUT_WIDTH-1:0]           data_out_tdata_array [RATE_CHANGE-1:0];
+    wire [RATE_CHANGE-1:0]              data_out_tready_array;
+    wire [RATE_CHANGE-1:0]              data_out_tvalid_array;
+    wire [RATE_CHANGE-1:0]              data_out_tlast_array;
+    wire [RATE_CHANGE-1:0]              coeffs_axi_wready_array;
+    reg [RATE_CHANGE-1:0]               coeffs_axi_wvalid_array;
+    wire [RATE_CHANGE-1:0]              coeffs_axi_tlast_array;
 
-	// flip the logic of the reset signal
-	assign reset = !data_in_aresetn | (data_out_tlast & data_out_tvalid & data_out_tready);
-
-
-	////// Control logic to load the coefficients into the FIR filters
-
-	// coefficients are always ready
-	//  however the module should be reset before coefficients are reloaded
-	assign coefficients_in_tready = &coefficients_in_tready_array;
-
-	// count how much of the filter has been filled and create signals for loading
-	always @(posedge clock) begin
-		if (reset | coefficients_in_tlast | data_out_tlast) begin
-			coefficients_in_tvalid_array <= 1;
-		end
-		else begin
-			// valid inputs, shift the register
-			if (coefficients_in_tvalid & coefficients_in_tready) begin
-				coefficients_in_tvalid_array <= {coefficients_in_tvalid_array[RATE_CHANGE-2:0], coefficients_in_tvalid_array[RATE_CHANGE-1]};
-			end
-			else begin
-				coefficients_in_tvalid_array <= coefficients_in_tvalid_array;
-			end
-		end
-	end
+    wire [RATE_CHANGE-1:0]              samples_remaining_array;
 
 
+    // select the highest frequency clock
+    assign clock = DECIMATE_INTERPOLATE ? data_out_aclk : data_in_aclk;
 
-	////// Control logic to arrange data into and out of the FIR filter stages
-
-	genvar i;
-	generate
-		if (DECIMATE_INTERPOLATE == 0) begin
-
-			// DECIMATION IS STILL TO BE IMPLEMENTED
-
-		end
-		else begin
-
-			// map signals to each of the filter sections
-			for (i = 0; i < RATE_CHANGE; i = i + 1) begin
-
-				// register the input data
-				always @(posedge clock) begin
-					if(reset) begin
-						data_in_tdata_array[i] <= 0;
-					end
-					else begin
-						if (data_in_tvalid & data_in_tready) begin
-							data_in_tdata_array[i] = data_in_tdata;
-						end
-						else begin
-							data_in_tdata_array[i] = data_in_tdata_array[i];
-						end
-					end
-				end
-
-				// register the input last signal to each filter section
-				always @(posedge clock) begin
-					if(reset) begin
-						data_in_tlast_array[i] <= 0;
-					end
-					else begin
-						if (data_in_tvalid & data_in_tready & data_in_tlast) begin
-							data_in_tlast_array[i] = data_in_tlast;
-						end
-						else begin
-							data_in_tlast_array[i] = data_in_tlast_array[i];
-						end
-					end
-				end
-			end
-
-			// form the input ready signal when filter sections are ready and we're at the correct
-			// phase
-			assign data_in_tready = (|data_in_tready_array) & (phase_counter == (RATE_CHANGE-1));
-
-			// the output ready array depends on the current phase
-			assign data_out_tready_array = {RATE_CHANGE{data_out_tready}} & 2**phase_counter;
+    // flip the logic of the reset signal
+    assign reset = !data_in_aresetn | (data_out_tlast & data_out_tvalid & data_out_tready);
 
 
-			// create the data valid signals for each filter
-			always @(posedge clock) begin
-				if(reset) begin
-					data_in_tvalid_array <= 0;
-				end
-				else begin
+    ////// Control logic to load the coeffs into the FIR filters
 
-					// register input valid signals for each filter section
-					if (data_in_tvalid & data_in_tvalid) begin
-						data_in_tvalid_array <= {RATE_CHANGE{data_in_tvalid}};
-					end
-					else begin
-						data_in_tvalid_array <= data_in_tvalid_array;
-					end
-				end
-			end
+    // coeffs are always ready
+    //  however the module should be reset before coeffs are reloaded
+    assign coeffs_axi_wready = &coeffs_axi_wready_array;
 
-			// use a phase counter to control how the polyphase filter moves between
-			// each phase
-			always @(posedge clock) begin
-				if(reset) begin
-					phase_counter <= RATE_CHANGE-1;
-				end
-				else begin
-
-					// increment the phase counter if the input is valid, ready and the output is ready or if we're trying to clear
-					//   samples out at the end
-					if ((data_in_tvalid & data_out_tready & (|data_in_tready_array)) | (data_out_tready & data_in_tlast_latched)) begin
-						phase_counter <= (phase_counter + 1) % RATE_CHANGE;
-					end
-					else begin
-						phase_counter <= phase_counter;
-					end
-
-				end
-			end
-
-			// map the correct filter output signal to the modules output
-			//  depending on the phase counter
-			assign data_out_tdata = data_out_tdata_array[(phase_counter-1)%RATE_CHANGE];
-
-			// latch the input last sample signals
-			always @(posedge clock) begin
-				if(reset) begin
-					data_in_tlast_latched <= 0;
-				end
-				else begin
-					data_in_tlast_latched <= !data_out_tlast & (data_in_tlast_latched | data_in_tlast);
-				end
-			end
-
-			// use the last sample signal from the last filter
-			assign data_out_tlast = data_out_tlast_array[RATE_CHANGE-1];
-
-			// change which signal is mapped to the output depending of the phase of the filter
-			assign data_out_tvalid = data_out_tvalid_array[(phase_counter-1) % RATE_CHANGE] ;
-		end
-	endgenerate
-
-
-	// create the parallel FIR filters
-	genvar dsp_array;
-	generate
-	for (dsp_array=0; dsp_array < RATE_CHANGE; dsp_array=dsp_array+1)
-		begin : fir_filter
-
-			fir_filter #(
-				.NUMBER_TAPS(SUB_LENGTH),
-				.DATA_IN_WIDTH(DATA_IN_WIDTH),
-				.COEFFICIENT_WIDTH(COEFFICIENT_WIDTH),
-				.DATA_OUT_WIDTH(DATA_OUT_WIDTH)
-			) fir_filter_inst (
-				.data_in_aclk(data_in_aclk),
-				.data_in_aresetn(data_in_aresetn & !reset),
-				.data_in_tready(data_in_tready_array[dsp_array]),
-				.data_in_tdata(data_in_tdata_array[dsp_array]),
-				.data_in_tlast(data_in_tlast_array[dsp_array]),
-				.data_in_tvalid(data_in_tvalid_array[dsp_array]),
-				.data_out_aclk(data_out_aclk),
-				.data_out_aresetn(data_out_aresetn),
-				.data_out_tready(data_out_tready_array[dsp_array]),
-				.data_out_tdata(data_out_tdata_array[dsp_array]),
-				.data_out_tlast(data_out_tlast_array[dsp_array]),
-				.data_out_tvalid(data_out_tvalid_array[dsp_array]),
-				.coefficients_in_aclk(coefficients_in_aclk),
-				.coefficients_in_aresetn(coefficients_in_aresetn),
-				.coefficients_in_tready(coefficients_in_tready_array[dsp_array]),
-				.coefficients_in_tdata(coefficients_in_tdata),
-				.coefficients_in_tlast(coefficients_in_tlast_array[dsp_array]),
-				.coefficients_in_tvalid(coefficients_in_tvalid_array[dsp_array] & coefficients_in_tvalid),
-				.samples_remaining(samples_remaining_array[dsp_array])
-			);
-		end
-	endgenerate
+    // count how much of the filter has been filled and create signals for loading
+    always @(posedge clock) begin
+        if (reset | data_out_tlast | !coeffs_axi_aresetn) begin
+            coeffs_axi_wvalid_array <= 1;
+        end
+        else begin
+            // valid inputs, shift the register
+            if (coeffs_axi_wvalid & coeffs_axi_wready) begin
+                coeffs_axi_wvalid_array <= {coeffs_axi_wvalid_array[RATE_CHANGE-2:0], coeffs_axi_wvalid_array[RATE_CHANGE-1]};
+            end
+            else begin
+                coeffs_axi_wvalid_array <= coeffs_axi_wvalid_array;
+            end
+        end
+    end
 
 
 
-	// // used to create the GTKwave dump file
-	// `ifdef COCOTB_SIM
-	// 	initial begin
-	// 		$dumpfile ("waveform.vcd");
-	// 		$dumpvars (0, polyphase_filter);
-	// 		#1;
-	// 	end
-	// `endif
+    ////// Control logic to arrange data into and out of the FIR filter stages
+
+    genvar i;
+    generate
+        if (DECIMATE_INTERPOLATE == 0) begin
+
+            // DECIMATION IS STILL TO BE IMPLEMENTED
+
+        end
+        else begin
+
+            // map signals to each of the filter sections
+            for (i = 0; i < RATE_CHANGE; i = i + 1) begin
+                
+                // register the input data
+                always @(posedge clock) begin
+                    if(reset) begin
+                        data_in_tdata_array[i] <= 0;
+                    end
+                    else begin
+                        if (data_in_tvalid & data_in_tready) begin
+                            data_in_tdata_array[i] = data_in_tdata;
+                        end
+                        else begin
+                            data_in_tdata_array[i] = data_in_tdata_array[i];
+                        end
+                    end
+                end
+
+                // register the input last signal to each filter section
+                always @(posedge clock) begin
+                    if(reset) begin
+                        data_in_tlast_array[i] <= 0;
+                    end
+                    else begin
+                        if (data_in_tvalid & data_in_tready & data_in_tlast) begin
+                            data_in_tlast_array[i] <= data_in_tlast;
+                        end
+                        else begin
+                            data_in_tlast_array[i] <= data_in_tlast_array[i];
+                        end
+                    end
+                end
+            end
+
+            // form the input ready signal when filter sections are ready and we're at the correct
+            // phase
+            assign data_in_tready = (|data_in_tready_array) & (phase_counter == (RATE_CHANGE-1));
+
+            // the output ready array depends on the current phase
+            assign data_out_tready_array = {RATE_CHANGE{data_out_tready}} & 2**phase_counter;
+
+
+            // create the data valid signals for each filter
+            always @(posedge clock) begin
+                if(reset) begin
+                    data_in_tvalid_array <= 0;
+                end
+                else begin
+
+                    // register input valid signals for each filter section
+                    if (data_in_tvalid & data_in_tvalid) begin
+                        data_in_tvalid_array <= {RATE_CHANGE{data_in_tvalid}};
+                    end
+                    else begin
+                        data_in_tvalid_array <= data_in_tvalid_array;
+                    end
+                end
+            end
+
+            // use a phase counter to control how the polyphase filter moves between
+            // each phase
+            always @(posedge clock) begin
+                if(reset) begin
+                    phase_counter <= RATE_CHANGE-1;
+                end
+                else begin
+
+                    // increment the phase counter if the input is valid, ready and the output is ready or if we're trying to clear
+                    //   samples out at the end 
+                    if ((data_in_tvalid & data_out_tready & (|data_in_tready_array)) | (data_out_tready & data_in_tlast_latched)) begin
+                        phase_counter <= (phase_counter + 1) % RATE_CHANGE;
+                    end
+                    else begin
+                        phase_counter <= phase_counter;
+                    end
+
+                end
+            end
+
+            // map the correct filter output signal to the modules output
+            //  depending on the phase counter
+            assign data_out_tdata = data_out_tdata_array[(phase_counter-1)%RATE_CHANGE];
+
+            // latch the input last sample signals
+            always @(posedge clock) begin
+                if(reset) begin
+                    data_in_tlast_latched <= 0;
+                end
+                else begin
+                    data_in_tlast_latched <= !data_out_tlast & (data_in_tlast_latched | data_in_tlast);
+                end
+            end
+
+            // use the last sample signal from the last filter
+            assign data_out_tlast = data_out_tlast_array[RATE_CHANGE-1];
+
+            // change which signal is mapped to the output depending of the phase of the filter
+            assign data_out_tvalid = data_out_tvalid_array[(phase_counter-1) % RATE_CHANGE] ;
+        end
+    endgenerate
+
+
+    // create the parallel FIR filters
+    genvar dsp_array;
+    generate
+    for (dsp_array=0; dsp_array < RATE_CHANGE; dsp_array=dsp_array+1)
+        begin : fir_filter
+
+            fir_filter #(
+                .NUMBER_TAPS(SUB_LENGTH),
+                .DATA_IN_WIDTH(DATA_IN_WIDTH),
+                .COEFFICIENT_WIDTH(COEFFICIENT_WIDTH),
+                .DATA_OUT_WIDTH(DATA_OUT_WIDTH)
+            ) fir_filter_inst (
+                .data_in_aclk(data_in_aclk),
+                .data_in_aresetn(data_in_aresetn & !reset),
+                .data_in_tready(data_in_tready_array[dsp_array]),
+                .data_in_tdata(data_in_tdata_array[dsp_array]),
+                .data_in_tlast(data_in_tlast_array[dsp_array]),
+                .data_in_tvalid(data_in_tvalid_array[dsp_array]),
+                .data_out_aclk(data_out_aclk),
+                .data_out_aresetn(data_out_aresetn),
+                .data_out_tready(data_out_tready_array[dsp_array]),
+                .data_out_tdata(data_out_tdata_array[dsp_array]),
+                .data_out_tlast(data_out_tlast_array[dsp_array]),
+                .data_out_tvalid(data_out_tvalid_array[dsp_array]),
+                .coeffs_axi_aclk(coeffs_axi_aclk),
+                .coeffs_axi_aresetn(coeffs_axi_aresetn),
+                .coeffs_axi_awvalid(coeffs_axi_awvalid),
+                .coeffs_axi_awready(coeffs_axi_awready),
+                .coeffs_axi_awaddr(coeffs_axi_awaddr),
+                .coeffs_axi_awprot(coeffs_axi_awprot),
+                .coeffs_axi_wvalid(coeffs_axi_wvalid_array[dsp_array] & coeffs_axi_wvalid),
+                .coeffs_axi_wready(coeffs_axi_wready_array[dsp_array]),
+                .coeffs_axi_wdata(coeffs_axi_wdata),
+                .coeffs_axi_wstrb(coeffs_axi_wstrb),
+                .coeffs_axi_bvalid(coeffs_axi_bvalid),
+                .coeffs_axi_bready(coeffs_axi_bready),
+                .coeffs_axi_bresp(coeffs_axi_bresp),
+                .coeffs_axi_arvalid(coeffs_axi_arvalid),
+                .coeffs_axi_arready(coeffs_axi_arready),
+                .coeffs_axi_araddr(coeffs_axi_araddr),
+                .coeffs_axi_arprot(coeffs_axi_arprot),
+                .coeffs_axi_rvalid(coeffs_axi_rvalid),
+                .coeffs_axi_rready(coeffs_axi_rready),
+                .coeffs_axi_rdata(coeffs_axi_rdata),
+                .coeffs_axi_rresp(coeffs_axi_rresp),
+                .samples_remaining(samples_remaining_array[dsp_array])
+            );
+        end
+    endgenerate
+
+
+
+    // used to create the GTKwave dump file
+    `ifdef COCOTB_SIM
+        initial begin
+            $dumpfile ("waveform.vcd");
+            $dumpvars (0, polyphase_filter);
+            #1;
+        end
+    `endif
 
 endmodule


### PR DESCRIPTION
- Fixed error in bit slicing in at output of MAC causing incorrect outputs
- Changed from AXI-stream to AXI-lite interface for coefficients
- Updated top-level and testbench for the AXI-lite interface
- Added filter coefficient generator using the GNURadio firdes module
- Updated testbench filter coefficients and rate change to match GNURadio flowgraph reference